### PR TITLE
Support OTP 26.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         otp: ['24.0', '25.0', '26.0']
-        toolchain: [stable, beta]
+        toolchain: [stable]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [stable, beta, nightly]
+        otp: ['24.0', '25.0', '26.0']
+        toolchain: [stable, beta]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
       - name: Install ${{ matrix.toolchain }} toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '26.0'
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -144,7 +144,7 @@ impl DistributionFlags {
     ///
     /// ```
     /// # use erl_dist::DistributionFlags;
-    /// DistributionFlags::mandatory() | DistributionFlags::HANDSHAKE_23;
+    /// DistributionFlags::mandatory()
     /// ```
     pub fn new() -> Self {
         Self::mandatory()

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -122,6 +122,12 @@ bitflags::bitflags! {
         ///
         /// Introduced in OTP 24.
         const ALIAS = 1 << 35;
+
+        /// The node supports all capabilities that are mandatory in OTP 25.
+        ///
+        /// Introduced in OTP 25.
+        /// [NOTE] This flag will become mandatory in OTP 27.
+        const MANDATORY_25_DIGEST = 1 << 36;
     }
 }
 
@@ -141,7 +147,7 @@ impl DistributionFlags {
     /// DistributionFlags::mandatory() | DistributionFlags::HANDSHAKE_23;
     /// ```
     pub fn new() -> Self {
-        Self::mandatory() | Self::HANDSHAKE_23
+        Self::mandatory()
     }
 
     /// Gets the mandatory flags (in OTP 26).
@@ -156,6 +162,8 @@ impl DistributionFlags {
             | Self::UTF8_ATOMS
             | Self::MAP_TAGS
             | Self::BIG_CREATION
+            | Self::HANDSHAKE_23
+            | Self::MANDATORY_25_DIGEST
             | Self::UNLINK_ID
             | Self::V4_NC
     }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -144,7 +144,7 @@ impl DistributionFlags {
     ///
     /// ```
     /// # use erl_dist::DistributionFlags;
-    /// DistributionFlags::mandatory()
+    /// DistributionFlags::mandatory();
     /// ```
     pub fn new() -> Self {
         Self::mandatory()

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -144,7 +144,7 @@ impl DistributionFlags {
         Self::mandatory() | Self::HANDSHAKE_23
     }
 
-    /// Gets the mandatory flags (in OTP 25).
+    /// Gets the mandatory flags (in OTP 26).
     pub fn mandatory() -> Self {
         Self::EXTENDED_REFERENCES
             | Self::FUN_TAGS
@@ -156,5 +156,7 @@ impl DistributionFlags {
             | Self::UTF8_ATOMS
             | Self::MAP_TAGS
             | Self::BIG_CREATION
+            | Self::UNLINK_ID
+            | Self::V4_NC
     }
 }

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -97,13 +97,6 @@ where
     async fn send_name(&mut self, protocol_version: u16) -> Result<(), HandshakeError> {
         let mut writer = self.connection.handshake_message_writer();
         match protocol_version {
-            5 => {
-                writer.write_u8(b'n')?;
-                writer.write_u16(5)?;
-                writer.write_u32(self.local_node.flags.bits() as u32)?;
-                writer.write_all(self.local_node.name.to_string().as_bytes())?;
-                self.may_need_complement = true;
-            }
             6 => {
                 writer.write_u8(b'N')?;
                 writer.write_u64(self.local_node.flags.bits())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ mod io;
 pub use self::flags::DistributionFlags;
 
 /// The lowest distribution protocol version this crate can handle.
-pub const LOWEST_DISTRIBUTION_PROTOCOL_VERSION: u16 = 5;
+pub const LOWEST_DISTRIBUTION_PROTOCOL_VERSION: u16 = 6;
 
 /// The highest distribution protocol version this crate can handle.
 pub const HIGHEST_DISTRIBUTION_PROTOCOL_VERSION: u16 = 6;


### PR DESCRIPTION
- Update default distribution flags to include mandatory flags since OTP 26.0
- Change lowest distribution protocol version from 5 to 6