### PR TITLE
Remove `thiserror`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ eetf = "0.9"
 futures = "0.3"
 md5 = "0.7"
 rand = "0.9"
-thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"

--- a/src/node.rs
+++ b/src/node.rs
@@ -41,22 +41,40 @@ pub struct PeerNode {
 }
 
 /// Errors that can occur while parsing node names.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum NodeNameError {
-    #[error("node name length must be less than 256, but got {size} characters")]
+    /// Node name length must be less than 256.
     TooLongName { size: usize },
 
-    #[error("the name part of a node name is empty")]
+    /// Name part of a node name is empty.
     EmptyName,
 
-    #[error("the host part of a node name is empty")]
+    /// Host part of a node name is empty.
     EmptyHost,
 
-    #[error("node name must contain an '@' character")]
+    /// Node name must contain an '@' character.
     MissingAtmark,
 }
+
+impl std::fmt::Display for NodeNameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooLongName { size } => {
+                write!(
+                    f,
+                    "node name length must be less than 256, but got {size} characters"
+                )
+            }
+            Self::EmptyName => write!(f, "the name part of a node name is empty"),
+            Self::EmptyHost => write!(f, "the host part of a node name is empty"),
+            Self::MissingAtmark => write!(f, "node name must contain an '@' character"),
+        }
+    }
+}
+
+impl std::error::Error for NodeNameError {}
 
 /// Full node name with the format "{NAME}@{HOST}".
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Copilot Summary
----------------------------

This pull request includes several changes to error handling and error messages in the codebase. The most significant changes involve removing the `thiserror` dependency and implementing custom error formatting and conversion for various error types.

Error handling improvements:

* [`src/channel.rs`](diffhunk://#diff-5cb8d80357286351f074b2bac08638050f4bb5e278bc9f4160897a895cc525fcL110-R205): Removed `thiserror` dependency and added custom implementations for `std::fmt::Display` and `std::error::Error` for `SendError` and `RecvError` enums.
* [`src/epmd.rs`](diffhunk://#diff-4f2b2fb3ea52e0c8a582a40db55efcb4f3a9855dba2be743d8ef136ac68891b8L94-R165): Removed `thiserror` dependency and added custom implementations for `std::fmt::Display` and `std::error::Error` for `EpmdError` enum.
* [`src/handshake.rs`](diffhunk://#diff-2ad36d202f590d8f8d5501411e8b4fc0b7cffa91b007e695176610fb981f7673L536-R641): Removed `thiserror` dependency and added custom implementations for `std::fmt::Display` and `std::error::Error` for `HandshakeError` enum.
* [`src/node.rs`](diffhunk://#diff-af08c3181737aa5783b96dfd920cd5ef70829f46cd1b697bdb42414c97310e13L44-R78): Removed `thiserror` dependency and added custom implementations for `std::fmt::Display` and `std::error::Error` for `NodeNameError` enum.

Code simplification:

* [`src/handshake.rs`](diffhunk://#diff-2ad36d202f590d8f8d5501411e8b4fc0b7cffa91b007e695176610fb981f7673L9-R16): Introduced constants `PROTOCOL_VERSION` and `NODE_NAME_VERSION` to replace hardcoded values, improving code readability and maintainability. [[1]](diffhunk://#diff-2ad36d202f590d8f8d5501411e8b4fc0b7cffa91b007e695176610fb981f7673L9-R16) [[2]](diffhunk://#diff-2ad36d202f590d8f8d5501411e8b4fc0b7cffa91b007e695176610fb981f7673L100-R103) [[3]](diffhunk://#diff-2ad36d202f590d8f8d5501411e8b4fc0b7cffa91b007e695176610fb981f7673L171-R174) [[4]](diffhunk://#diff-2ad36d202f590d8f8d5501411e8b4fc0b7cffa91b007e695176610fb981f7673L288-R291)