### PR TITLE
Update dev dependencies (clap, smol, anyhow->orfail)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ md5 = "0.7"
 rand = "0.9"
 
 [dev-dependencies]
-anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+orfail = "1.1.0"
 serde_json = "1"
 smol = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ rand = "0.9"
 
 [dev-dependencies]
 anyhow = "1"
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 smol = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ rand = "0.9"
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
 serde_json = "1"
-smol = "1"
+smol = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! # use smol::net::TcpStream;
 //! use erl_dist::epmd::{DEFAULT_EPMD_PORT, EpmdClient};
 //!
-//! # fn main() -> anyhow::Result<()> {
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # smol::block_on(async {
 //! // Connect to the local EPMD.
 //! let connection = TcpStream::connect(("localhost", DEFAULT_EPMD_PORT)).await?;
@@ -38,7 +38,7 @@
 //! use erl_dist::term::{Atom, Pid};
 //! use erl_dist::message::{channel, Message};
 //!
-//! # fn main() -> anyhow::Result<()> {
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # smol::block_on(async {
 //! // Connect to a peer node.
 //! let peer_host = "localhost";


### PR DESCRIPTION
Copilot Summary
-----------------------------

This pull request includes several updates to dependencies and refactors error handling in multiple example files to use the `orfail` crate instead of `anyhow`. The most important changes include updating the `Cargo.toml` dependencies, modifying the error handling in example files, and updating the test module in `src/lib.rs`.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L22-R25): Updated `clap` to version 4, added `orfail` version 1.1.0, and updated `smol` to version 2.

Error handling refactor:

* [`examples/epmd_cli.rs`](diffhunk://#diff-b6e4456904738f83600cabdd6b805593b0cc12cff745a3f4c6dafea1d4c873f6R12): Replaced `anyhow` with `orfail` for error handling and added `orfail::OrFail` import. [[1]](diffhunk://#diff-b6e4456904738f83600cabdd6b805593b0cc12cff745a3f4c6dafea1d4c873f6R12) [[2]](diffhunk://#diff-b6e4456904738f83600cabdd6b805593b0cc12cff745a3f4c6dafea1d4c873f6L45-R68) [[3]](diffhunk://#diff-b6e4456904738f83600cabdd6b805593b0cc12cff745a3f4c6dafea1d4c873f6L75-R89) [[4]](diffhunk://#diff-b6e4456904738f83600cabdd6b805593b0cc12cff745a3f4c6dafea1d4c873f6L98-R102)
* [`examples/handshake.rs`](diffhunk://#diff-2c8cb830e77aee722ac5a47fd7bdeb3a87da9438e648ca7d19953855fbc7a456R10): Replaced `anyhow` with `orfail` for error handling and added `orfail::OrFail` import. [[1]](diffhunk://#diff-2c8cb830e77aee722ac5a47fd7bdeb3a87da9438e648ca7d19953855fbc7a456R10) [[2]](diffhunk://#diff-2c8cb830e77aee722ac5a47fd7bdeb3a87da9438e648ca7d19953855fbc7a456L27-R52) [[3]](diffhunk://#diff-2c8cb830e77aee722ac5a47fd7bdeb3a87da9438e648ca7d19953855fbc7a456L61-R79)
* [`examples/recv_msg.rs`](diffhunk://#diff-fc7b3166c87eb78c0dd4f11e70e6440950aa8cc67e3ed87fb587858cd750b11eR18): Replaced `anyhow` with `orfail` for error handling and added `orfail::OrFail` import. [[1]](diffhunk://#diff-fc7b3166c87eb78c0dd4f11e70e6440950aa8cc67e3ed87fb587858cd750b11eR18) [[2]](diffhunk://#diff-fc7b3166c87eb78c0dd4f11e70e6440950aa8cc67e3ed87fb587858cd750b11eL36-R48) [[3]](diffhunk://#diff-fc7b3166c87eb78c0dd4f11e70e6440950aa8cc67e3ed87fb587858cd750b11eL60-R66) [[4]](diffhunk://#diff-fc7b3166c87eb78c0dd4f11e70e6440950aa8cc67e3ed87fb587858cd750b11eL93-R97) [[5]](diffhunk://#diff-fc7b3166c87eb78c0dd4f11e70e6440950aa8cc67e3ed87fb587858cd750b11eL105-R106) [[6]](diffhunk://#diff-fc7b3166c87eb78c0dd4f11e70e6440950aa8cc67e3ed87fb587858cd750b11eL119-R120)
* [`examples/send_msg.rs`](diffhunk://#diff-73453e4e1733d553fef97dfeb46edfe23aa77ef760b65174a5b48dca4b80481fR12): Replaced `anyhow` with `orfail` for error handling and added `orfail::OrFail` import. [[1]](diffhunk://#diff-73453e4e1733d553fef97dfeb46edfe23aa77ef760b65174a5b48dca4b80481fR12) [[2]](diffhunk://#diff-73453e4e1733d553fef97dfeb46edfe23aa77ef760b65174a5b48dca4b80481fL35-R66) [[3]](diffhunk://#diff-73453e4e1733d553fef97dfeb46edfe23aa77ef760b65174a5b48dca4b80481fL72-R77)

Test module updates:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R99-R100): Updated test module to use `orfail` for error handling and added `orfail::OrFail` import. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R99-R100) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L107-R117) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L133-R141)